### PR TITLE
docs: align README metrics table with code output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ swift run hlsmonitor "https://devstreaming-cdn.apple.com/videos/streaming/exampl
 |--------|-------------|
 | Time | Current timestamp |
 | Position | Current playback position |
-| Duration | Total stream duration |
+| Stream Duration | Total stream duration |  # Changed from "Duration"
 | Quality | Video resolution |
 | Indicated | Indicated bitrate |
 | Observed | Observed bitrate |


### PR DESCRIPTION
changed duration to be more clear and added it into README